### PR TITLE
DM-18405: Improved UX for dialogs through templatekit.yaml configs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,23 @@
 Change log
 ##########
 
+0.0.3 (2019-03-18)
+==================
+
+This release focuses on refining the user experience of creating a file or project from Slack using the ``templatekit.yaml`` configuration files introduced in Templatekit 0.2.0.
+
+- In the initial template selection menus, template names and groupings are derived from ``templatekit.yaml`` configurations.
+  Templates are now better organized and better labeled!
+
+- Fields in the dialog are driven by the ``dialog_fields`` field in ``templatekit.yaml`` configurations (Templatekit will still provide a default set of fields if none are set).
+  These configurations, defined in Templatekit 0.2.0+ allow for exciting UI features like labels, placeholders, and hints.
+  The schema validator in Templatekit ensures that labels aren't too long, and that there aren't too many dialog fields — this makes the dialog implementation in Templatebot much simpler.
+
+  These configurations also introduce the concept of *preset menus*, which combine multiple cookiecutter variable presets into selection menu options.
+  This feature lets us handle complicated templates, which many boolean or constrained option variables, within the five-field limit imposed by Slack dialogs.
+
+- This release also includes a handler for project templates, though only as a proof-of-concept for showing that cookiecutter variables for complex templates like ``stack_package`` can be successfully captured.
+
 0.0.2 (2019-03-12)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'fastavro==0.21.16',
     'kafkit==0.1.1',
     'aiokafka==0.5.0',
-    'templatekit==0.1.1',
+    'templatekit==0.2.0a1',
 ]
 
 # Test dependencies

--- a/templatebot/config.py
+++ b/templatebot/config.py
@@ -68,6 +68,6 @@ def create_config():
     # Default Git ref for the template repository ('templatebot/repo')
     c['templatebot/repoRef'] = os.getenv(
         'TEMPLATEBOT_REPO_REF',
-        'master')
+        'tickets/DM-18406')
 
     return c

--- a/templatebot/slack/chatupdate.py
+++ b/templatebot/slack/chatupdate.py
@@ -1,0 +1,39 @@
+"""Slack helper for updating existing messages.
+"""
+
+__all__ = ('update_message',)
+
+
+async def update_message(*, body, logger, app):
+    """Send a ``chat.update`` request to Slack.
+
+    Parameters
+    ----------
+    body : `dict`
+        The ``chat.update`` payload. See
+        https://api.slack.com/methods/chat.update
+    logger
+        Logger instance.
+    app
+        Application instance.
+    """
+    httpsession = app['root']['api.lsst.codes/httpSession']
+    headers = {
+        'content-type': 'application/json; charset=utf-8',
+        'authorization': f'Bearer {app["root"]["templatebot/slackToken"]}'
+    }
+
+    logger.info(
+        'chat.update',
+        body=body)
+
+    url = 'https://slack.com/api/chat.update'
+    async with httpsession.post(url, json=body, headers=headers) as response:
+        response_json = await response.json()
+        logger.debug(
+            'chat.update reponse',
+            response=response_json)
+    if not response_json['ok']:
+        logger.error(
+            'Got a Slack error from chat.update',
+            contents=response_json)

--- a/templatebot/slack/dialog.py
+++ b/templatebot/slack/dialog.py
@@ -1,0 +1,116 @@
+"""Tools for opening Slack dialogs with template variables as fields.
+"""
+
+__all__ = ('open_template_dialog',)
+
+import json
+import uuid
+
+
+async def open_template_dialog(*, template, event_data, callback_id_root,
+                               logger, app):
+    """Open a Slack dialog containing fields based on the template.
+
+    Parameters
+    ----------
+    template : `templatekit.repo.BaseTemplate`
+        Template instance.
+    event_data : `dict`
+        The payload of the event.
+    callback_id_root : `str`
+        The root (prefix) of the ``dialog.callback_id`` field. This function
+        adds a UUID4 suffix to make the callback ID unique. The router can
+        find responses to this type of dialog by matching the ``callback_id``
+        of the ``dialog_submission`` event.
+    app : `aiohttp.web.Application`
+        The application instance.
+    logger
+        A structlog logger, typically with event information already
+        bound to it.
+    """
+    elements = _create_dialog_elements(template=template)
+
+    # State that's needed by handle_file_dialog_submission
+    state = {
+        'template_name': template.name
+    }
+    dialog_title = template.config['dialog_title']
+    dialog_body = {
+        'trigger_id': event_data['trigger_id'],
+        'dialog': {
+            "title": dialog_title,
+            "callback_id": f'{callback_id_root}_{str(uuid.uuid4())}',
+            'state': json.dumps(state),
+            'notify_on_cancel': True,
+            'elements': elements
+        }
+    }
+
+    httpsession = app['root']['api.lsst.codes/httpSession']
+    headers = {
+        'content-type': 'application/json; charset=utf-8',
+        'authorization': f'Bearer {app["root"]["templatebot/slackToken"]}'
+    }
+    url = 'https://slack.com/api/dialog.open'
+    async with httpsession.post(url, json=dialog_body, headers=headers) \
+            as response:
+        response_json = await response.json()
+        logger.info(
+            'templatebot_file_select reponse',
+            response=response_json)
+    if not response_json['ok']:
+        logger.error(
+            'Got a Slack error from dialog.open',
+            contents=response_json)
+
+
+def _create_dialog_elements(*, template):
+    elements = []
+    for field in template.config['dialog_fields']:
+        if field['component'] == 'select':
+            element = _generate_select_element(
+                field=field
+            )
+        else:
+            element = _generate_text_element(
+                field=field
+            )
+        elements.append(element)
+
+    if len(elements) > 5:
+        # This is the maximum length supported by Slack dialogs at the moment.
+        elements = elements[:5]
+
+    return elements
+
+
+def _generate_select_element(*, field):
+    """Generate the JSON specification of a ``select`` element in a dialog.
+    """
+    option_elements = []
+    for v in field['options']:
+        option_elements.append({'label': v['label'], 'value': v['value']})
+    element = {
+        'label': field['label'],
+        'type': 'select',
+        'name': field['key'],
+        'options': option_elements,
+        'optional': field['optional'],
+    }
+    return element
+
+
+def _generate_text_element(*, field):
+    """Generate the JSON specification of a text element in a dialog.
+    """
+    element = {
+        'label': field['label'],
+        'name': field['key'],
+        "type": "text",
+        'optional': field['optional'],
+    }
+    if 'placeholder' in field and len(field['placeholder']) > 0:
+        element['placeholder'] = field['placeholder']
+    if 'hint' in field and len(field['hint']) > 0:
+        element['hint'] = field['hint']
+    return element

--- a/templatebot/slack/handlers/__init__.py
+++ b/templatebot/slack/handlers/__init__.py
@@ -3,3 +3,4 @@ from .filelisting import *
 from .fileselect import *
 from .projectlisting import *
 from .projectselect import *
+from .projectdialogsubmission import *

--- a/templatebot/slack/handlers/__init__.py
+++ b/templatebot/slack/handlers/__init__.py
@@ -2,3 +2,4 @@ from .filedialogsubmission import *
 from .filelisting import *
 from .fileselect import *
 from .projectlisting import *
+from .projectselect import *

--- a/templatebot/slack/handlers/filedialogsubmission.py
+++ b/templatebot/slack/handlers/filedialogsubmission.py
@@ -26,6 +26,15 @@ async def handle_file_dialog_submission(*, event_data, logger, app):
     )
     template = repo[template_name]
 
+    # Replace any truncated values from select fields with full values
+    for field in template.config['dialog_fields']:
+        if field['component'] == 'select':
+            selected_value = submission_data[field['key']]
+            for option in field['options']:
+                if option['value'] == selected_value:
+                    submission_data[field['key']] = option['template_value']
+                    continue
+
     await render_template(
         template=template,
         template_variables=submission_data,

--- a/templatebot/slack/handlers/filedialogsubmission.py
+++ b/templatebot/slack/handlers/filedialogsubmission.py
@@ -26,6 +26,10 @@ async def handle_file_dialog_submission(*, event_data, logger, app):
     )
     template = repo[template_name]
 
+    # Drop any null fields so that we get the defaults from cookiecutter.
+    submission_data = {k: v for k, v in submission_data.items()
+                       if v is not None}
+
     # Replace any truncated values from select fields with full values
     for field in template.config['dialog_fields']:
         if field['component'] == 'select':

--- a/templatebot/slack/handlers/fileselect.py
+++ b/templatebot/slack/handlers/fileselect.py
@@ -187,7 +187,7 @@ def _generate_text_element(*, field):
         "type": "text",
         'optional': field['optional'],
     }
-    if 'placeholder' in field:
+    if 'placeholder' in field and len(field['placeholder']) > 0:
         element['placeholder'] = field['placeholder']
     if 'hint' in field and len(field['hint']) > 0:
         element['hint'] = field['hint']

--- a/templatebot/slack/handlers/fileselect.py
+++ b/templatebot/slack/handlers/fileselect.py
@@ -3,9 +3,8 @@
 
 __all__ = ('handle_file_select_action',)
 
-import json
-import uuid
-
+from templatebot.slack.dialog import open_template_dialog
+from templatebot.slack.chatupdate import update_message
 from .filedialogsubmission import render_template
 
 
@@ -35,19 +34,14 @@ async def handle_file_select_action(*, event_data, action_data, logger, app):
             template=template, event_data=event_data, logger=logger,
             app=app)
     else:
-        await _open_dialog(template=template, event_data=event_data,
-                           logger=logger, app=app)
+        await open_template_dialog(
+            template=template, callback_id_root='templatebot_file_dialog',
+            event_data=event_data, logger=logger, app=app)
 
 
 async def _confirm_selection(*, event_data, action_data, logger, app):
     """Confirm the menu selection by replacing the menu with a static message.
     """
-    httpsession = app['root']['api.lsst.codes/httpSession']
-    headers = {
-        'content-type': 'application/json; charset=utf-8',
-        'authorization': f'Bearer {app["root"]["templatebot/slackToken"]}'
-    }
-
     text_content = (
         f"<@{event_data['user']['id']}> :raised_hands: "
         "Nice! I'll help you create boilerplate for a "
@@ -68,21 +62,7 @@ async def _confirm_selection(*, event_data, action_data, logger, app):
             }
         ]
     }
-
-    logger.info(
-        'templatebot_file_select chat.update',
-        body=body)
-
-    url = 'https://slack.com/api/chat.update'
-    async with httpsession.post(url, json=body, headers=headers) as response:
-        response_json = await response.json()
-        logger.info(
-            'templatebot_file_select reponse',
-            response=response_json)
-    if not response_json['ok']:
-        logger.error(
-            'Got a Slack error from chat.update',
-            contents=response_json)
+    await update_message(body=body, logger=logger, app=app)
 
 
 async def _respond_with_nonconfigurable_content(*, template, event_data,
@@ -101,94 +81,3 @@ async def _respond_with_nonconfigurable_content(*, template, event_data,
         user_id=user_id,
         logger=logger,
         app=app)
-
-
-async def _open_dialog(*, template, event_data, logger, app):
-    """Open a Slack dialog containing fields based on the user query.
-    """
-    elements = _create_dialog_elements(template=template)
-
-    # State that's needed by handle_file_dialog_submission
-    state = {
-        'template_name': template.name
-    }
-    dialog_title = template.config['dialog_title']
-    dialog_body = {
-        'trigger_id': event_data['trigger_id'],
-        'dialog': {
-            "title": dialog_title,
-            "callback_id": f'templatebot_file_dialog_{str(uuid.uuid4())}',
-            'state': json.dumps(state),
-            'notify_on_cancel': True,
-            'elements': elements
-        }
-    }
-
-    httpsession = app['root']['api.lsst.codes/httpSession']
-    headers = {
-        'content-type': 'application/json; charset=utf-8',
-        'authorization': f'Bearer {app["root"]["templatebot/slackToken"]}'
-    }
-    url = 'https://slack.com/api/dialog.open'
-    async with httpsession.post(url, json=dialog_body, headers=headers) \
-            as response:
-        response_json = await response.json()
-        logger.info(
-            'templatebot_file_select reponse',
-            response=response_json)
-    if not response_json['ok']:
-        logger.error(
-            'Got a Slack error from dialog.open',
-            contents=response_json)
-
-
-def _create_dialog_elements(*, template):
-    elements = []
-    for field in template.config['dialog_fields']:
-        if field['component'] == 'select':
-            element = _generate_select_element(
-                field=field
-            )
-        else:
-            element = _generate_text_element(
-                field=field
-            )
-        elements.append(element)
-
-    if len(elements) > 5:
-        # This is the maximum length supported by Slack dialogs at the moment.
-        elements = elements[:5]
-
-    return elements
-
-
-def _generate_select_element(*, field):
-    """Generate the JSON specification of a ``select`` element in a dialog.
-    """
-    option_elements = []
-    for v in field['options']:
-        option_elements.append({'label': v['label'], 'value': v['value']})
-    element = {
-        'label': field['label'],
-        'type': 'select',
-        'name': field['key'],
-        'options': option_elements,
-        'optional': field['optional'],
-    }
-    return element
-
-
-def _generate_text_element(*, field):
-    """Generate the JSON specification of a text element in a dialog.
-    """
-    element = {
-        'label': field['label'],
-        'name': field['key'],
-        "type": "text",
-        'optional': field['optional'],
-    }
-    if 'placeholder' in field and len(field['placeholder']) > 0:
-        element['placeholder'] = field['placeholder']
-    if 'hint' in field and len(field['hint']) > 0:
-        element['hint'] = field['hint']
-    return element

--- a/templatebot/slack/handlers/fileselect.py
+++ b/templatebot/slack/handlers/fileselect.py
@@ -172,7 +172,8 @@ def _generate_select_element(*, field):
         'label': field['label'],
         'type': 'select',
         'name': field['key'],
-        'options': option_elements
+        'options': option_elements,
+        'optional': field['optional'],
     }
     return element
 
@@ -184,6 +185,7 @@ def _generate_text_element(*, field):
         'label': field['label'],
         'name': field['key'],
         "type": "text",
+        'optional': field['optional'],
     }
     if 'placeholder' in field:
         element['placeholder'] = field['placeholder']

--- a/templatebot/slack/handlers/projectdialogsubmission.py
+++ b/templatebot/slack/handlers/projectdialogsubmission.py
@@ -1,0 +1,34 @@
+"""Handle a project_dialog_submission event after the user has filled out
+a dialog with template configuration.
+"""
+
+__all__ = ('handle_project_dialog_submission',)
+
+import json
+
+from templatebot.slack.dialog import post_process_dialog_submission
+
+
+async def handle_project_dialog_submission(*, event_data, logger, app):
+    """Handle the dialog_submission interaction from a
+    ``templatebot_project_dialog``.
+    """
+    channel_id = event_data['channel']['id']
+    user_id = event_data['user']['id']
+    state = json.loads(event_data['state'])
+
+    template_name = state['template_name']
+    repo = app['templatebot/repo'].get_repo(
+        gitref=app['root']['templatebot/repoRef']
+    )
+    template = repo[template_name]
+
+    template_variables = post_process_dialog_submission(
+        submission_data=event_data['submission'],
+        template=template)
+    logger.info(
+        'project dialog submission',
+        variables=template_variables,
+        template=template.name,
+        user_id=user_id,
+        channel_id=channel_id)

--- a/templatebot/slack/handlers/projectselect.py
+++ b/templatebot/slack/handlers/projectselect.py
@@ -1,0 +1,58 @@
+"""Slack handler for when a user selects project template from a menu.
+"""
+
+__all__ = ('handle_project_select_action',)
+
+from templatebot.slack.dialog import open_template_dialog
+from templatebot.slack.chatupdate import update_message
+
+
+async def handle_project_select_action(*, event_data, action_data, logger,
+                                       app):
+    """Handle the selection from a ``templatebot_project_select`` action ID.
+
+    The key steps are:
+
+    1. Use the ``chat.update`` method to replace the original message
+       containing a selection menu with a confirmation message. This prevents
+       someone from interacting with the menu again.
+    2. Open a Slack dialog to let the user fill in template variables based
+       on the ``cookiecutter.json`` file.
+    """
+    await _confirm_selection(event_data=event_data, action_data=action_data,
+                             logger=logger, app=app)
+
+    selected_template = action_data['selected_option']['value']
+    repo = app['templatebot/repo'].get_repo(
+        gitref=app['root']['templatebot/repoRef']
+    )
+    template = repo[selected_template]
+    await open_template_dialog(template=template, event_data=event_data,
+                               callback_id_root="templatebot_project_dialog",
+                               logger=logger, app=app)
+
+
+async def _confirm_selection(*, event_data, action_data, logger, app):
+    """Confirm the menu selection by replacing the menu with a static message.
+    """
+    text_content = (
+        f"<@{event_data['user']['id']}> :raised_hands: "
+        "Nice! I'll help you create boilerplate for a "
+        f"`{action_data['selected_option']['text']['text']}` repo."
+    )
+    body = {
+        'token': app["root"]["templatebot/slackToken"],
+        'channel': event_data['container']['channel_id'],
+        'text': text_content,
+        "ts": event_data['container']['message_ts'],
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "text": text_content,
+                    "type": "mrkdwn"
+                }
+            }
+        ]
+    }
+    await update_message(body=body, logger=logger, app=app)

--- a/templatebot/slack/router.py
+++ b/templatebot/slack/router.py
@@ -12,7 +12,8 @@ import structlog
 
 from .handlers import (
     handle_project_creation, handle_file_creation,
-    handle_file_select_action, handle_file_dialog_submission
+    handle_file_select_action, handle_file_dialog_submission,
+    handle_project_select_action
 )
 
 
@@ -159,6 +160,11 @@ async def route_event(*, event, schema_id, topic, partition, offset, app):
                 logger.info(
                     'Got a templatebot_project_select',
                     value=action['selected_option']['value'])
+                await handle_project_select_action(
+                    event_data=event,
+                    action_data=action,
+                    logger=logger,
+                    app=app)
 
     elif 'type' in event and event['type'] == 'dialog_submission':
         if event['callback_id'].startswith('templatebot_file_dialog_'):

--- a/templatebot/slack/router.py
+++ b/templatebot/slack/router.py
@@ -13,7 +13,7 @@ import structlog
 from .handlers import (
     handle_project_creation, handle_file_creation,
     handle_file_select_action, handle_file_dialog_submission,
-    handle_project_select_action
+    handle_project_select_action, handle_project_dialog_submission
 )
 
 
@@ -172,6 +172,15 @@ async def route_event(*, event, schema_id, topic, partition, offset, app):
                 'Got a templatebot_file_dialog submission',
                 event_data=event)
             await handle_file_dialog_submission(
+                event_data=event,
+                logger=logger,
+                app=app
+            )
+        elif event['callback_id'].startswith('templatebot_project_dialog'):
+            logger.info(
+                'Got a templatebot_project_dialog submission',
+                event_data=event)
+            await handle_project_dialog_submission(
                 event_data=event,
                 logger=logger,
                 app=app


### PR DESCRIPTION
This release focuses on refining the user experience of creating a file or project from Slack using the `templatekit.yaml` configuration files introduced in Templatekit 0.2.0.

- In the initial template selection menus, template names and groupings are derived from `templatekit.yaml` configurations. Templates are now better organized and better labeled!

- Fields in the dialog are driven by the `dialog_fields` field in `templatekit.yaml` configurations (Templatekit will still provide a default set of fields if none are set). These configurations, defined in Templatekit 0.2.0+ allow for exciting UI features like labels, placeholders, and hints. The schema validator in Templatekit ensures that labels aren't too long, and that there aren't too many dialog fields — this makes the dialog implementation in Templatebot much simpler.

  These configurations also introduce the concept of *preset menus*, which combine multiple cookiecutter variable presets into selection menu options. This feature lets us handle complicated templates, which many boolean or constrained option variables, within the five-field limit imposed by Slack dialogs.

- This release also includes a handler for project templates, though only as a proof-of-concept for showing that cookiecutter variables for complex templates like ``stack_package`` can be successfully captured.

Here's what the dialog for a EUPS package template looks like now:

<img width="531" alt="Screen Shot 2019-03-18 at 2 27 11 PM" src="https://user-images.githubusercontent.com/349384/54570914-b9f44f80-499d-11e9-8e60-822ffa070c1f.png">
