### PR TITLE
DM-22075: Automatically refresh template clones with symbolic git refs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.0.7 (2019-11-04)
+==================
+
+- Templatebot now routinely checks if the template repository clone is up-to-date with the origin remote.
+  These checks are done whenever the template repository is being accessed, for instance in the handlers that list templates, that present template dialogs in Slack, or in rendering a template.
+  A template repository is only re-cloned if the local SHA does not match the SHA of the symbolic Git ref (branch or tag) on the origin.
+
 0.0.6 (2019-10-14)
 ==================
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: templatebot-app
-        image: lsstsqre/templatebot:0.0.6
+        image: lsstsqre/templatebot:0.0.7
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/templatebot/repo.py
+++ b/templatebot/repo.py
@@ -72,7 +72,7 @@ class RepoManager:
         return self._clones[head_sha]
 
     def get_checkout_path(self, gitref):
-        """Get the path to a cloned repositoryy for a given Git ref.
+        """Get the path to a cloned repository for a given Git ref.
 
         If a clone is available, the method makes a new clone.
 
@@ -87,10 +87,14 @@ class RepoManager:
             Path of the template repository clone.
         """
         if gitref in self._clones:
+            # The gitref is a SHA that's already been cloned.
             return self._clones[gitref]
         elif gitref in self._clone_refs:
+            # The gitref is a branch or tag name that's been cloned, but
+            # needs to be mapped to a SHA.
             return self._clones[self._clone_refs[gitref]]
         else:
+            # No record of this gitref; need to make a new clone
             return self.clone(gitref=gitref)
 
     def get_repo(self, gitref):


### PR DESCRIPTION
templatebot will now automatically check to make sure that the SHA of the branch it has cloned matches the origin. This is necessary when templatebot is tracking the master branch of the templates repository, for instance, and the master branch has been updated.

Fixes #5 