### PR TITLE
DM-25427: Update to aiokafka 0.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change log
 
 - Updated GitPython to 3.1.3 to resolve a floating dependency error related to the ``gitdb.utils.compat`` module.
 
+- Updated templatekit to 0.4.1, matching the version used by `lsst/templates <https://github.com/lsst/templates>`__.
+  This change also allowed us to float the version of Click so that it would be set by cookiecutter/templatekit.
+
 0.1.0 (2019-11-29)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Change log
 ##########
 
+0.1.1 (2020-06-15)
+==================
+
+- Update aiokafka to 0.6.0.
+  This should resolve the uncaught UnknownMemberId exception that was causing the templatebot Kafka consumer to drop its connection to the Kafka brokers.
+
+- Update kafkit to 0.2.0b3.
+
+- Updated testing stack to pytest 5.4.3 and pytest-flake8 to 1.0.6.
+
+- Updated GitPython to 3.1.3 to resolve a floating dependency error related to the ``gitdb.utils.compat`` module.
+
 0.1.0 (2019-11-29)
 ==================
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: templatebot-app
-        image: lsstsqre/templatebot:tickets-DM-22100
+        image: lsstsqre/templatebot
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - configmap.yaml
   - deployment.yaml
+
+images:
+  - name: lsstsqre/templatebot
+    newTag: 0.1.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'aiokafka==0.6.0',
     'templatekit==0.3.0',
     'confluent-kafka==0.11.6',
-    'GitPython==2.1.11',
+    'GitPython==3.1.3',
     'cachetools==3.1.0',
     'gidgethub==3.1.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'colorama==0.4.1',  # used by structlog
     'click>=6.7,<7.0',
     'fastavro==0.21.16',
-    'kafkit==0.1.1',
+    'kafkit==0.2.0b3',
     'aiokafka==0.5.2',
     'templatekit==0.3.0',
     'confluent-kafka==0.11.6',

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,11 @@ install_requires = [
     'cchardet==2.1.4',
     'structlog==18.2.0',
     'colorama==0.4.1',  # used by structlog
-    'click>=6.7,<7.0',
+    'click',
     'fastavro==0.21.16',
     'kafkit==0.2.0b3',
     'aiokafka==0.6.0',
-    'templatekit==0.3.0',
+    'templatekit==0.4.1',
     'confluent-kafka==0.11.6',
     'GitPython==3.1.3',
     'cachetools==3.1.0',

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ install_requires = [
 
 # Test dependencies
 tests_require = [
-    'pytest==4.2.0',
-    'pytest-flake8==1.0.4',
+    'pytest==5.4.3',
+    'pytest-flake8==1.0.6',
     'aiohttp-devtools==0.11',
 ]
 tests_require += install_requires

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'click>=6.7,<7.0',
     'fastavro==0.21.16',
     'kafkit==0.2.0b3',
-    'aiokafka==0.5.2',
+    'aiokafka==0.6.0',
     'templatekit==0.3.0',
     'confluent-kafka==0.11.6',
     'GitPython==2.1.11',


### PR DESCRIPTION
- Update aiokafka to 0.6.0. This should resolve the uncaught UnknownMemberId exception that was causing the templatebot Kafka consumer to drop its connection to the Kafka brokers.

- Update kafkit to 0.2.0b3.

- The Click dependency now floats so that it is determined by the cookiecutter and templatekit packages.