### PR TITLE
DM-52018: Remove environment_url from configuration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -79,7 +79,6 @@ def _make_env_vars(overrides: dict[str, str] | None = None) -> dict[str, str]:
         "KAFKA_BOOTSTRAP_SERVERS": "localhost:9092",
         "TEMPLATEBOT_PROFILE": "development",
         "TEMPLATEBOT_LOG_LEVEL": "DEBUG",
-        "TEMPLATEBOT_ENVIRONMENT_URL": "http://example.com/",
         "TEMPLATEBOT_SLACK_TOKEN": "xoxb-testing-123",
         "TEMPLATEBOT_SLACK_APP_ID": "A123456",
         "TEMPLATEBOT_TEMPLATE_REPO_URL": "https://github.com/lsst/templates",

--- a/src/templatebot/config.py
+++ b/src/templatebot/config.py
@@ -208,12 +208,6 @@ class Config(BaseSettings):
         LogLevel.INFO, title="Log level of the application's logger"
     )
 
-    environment_url: str = Field(
-        ...,
-        title="Environment URL",
-        examples=["https://roundtable.lsst.cloud"],
-    )
-
     kafka: KafkaConnectionSettings = Field(
         default_factory=KafkaConnectionSettings,
         title="Kafka connection configuration.",


### PR DESCRIPTION
Remove `Config.environment_url` from the Templatebot configuration. It was not used anywhere.

(I ran into this as a false positive while cataloging service discovery use cases.)